### PR TITLE
解决了用户密码可能泄露的Bug。

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -329,7 +329,7 @@ function Init_Panel(){
             exit 1
         fi
     done
-    sed -i -e "s#ORIGINAL_PASSWORD=.*#ORIGINAL_PASSWORD=#g" /usr/local/bin/1pctl
+    sed -i -e "s#ORIGINAL_PASSWORD=.*#ORIGINAL_PASSWORD=\*\*\*\*\*\*\*\*\*\*#g" /usr/local/bin/1pctl
 }
 
 function Get_Ip(){
@@ -366,7 +366,7 @@ function Show_Result(){
     log ""
     log "如果使用的是云服务器，请至安全组开放 $PANEL_PORT 端口"
     log ""
-    log "为了您的服务器安全，密码仅会显示一次，请牢记您的密码。"
+    log "为了您的服务器安全，在您离开此界面后您将无法再看到您的密码，请务必牢记您的密码。"
     log ""
     log "================================================================"
 }

--- a/install.sh
+++ b/install.sh
@@ -329,6 +329,7 @@ function Init_Panel(){
             exit 1
         fi
     done
+    sed -i -e "s#ORIGINAL_PASSWORD=.*#ORIGINAL_PASSWORD=#g" /usr/local/bin/1pctl
 }
 
 function Get_Ip(){
@@ -364,6 +365,8 @@ function Show_Result(){
     log "代码仓库: https://github.com/1Panel-dev/1Panel"
     log ""
     log "如果使用的是云服务器，请至安全组开放 $PANEL_PORT 端口"
+    log ""
+    log "为了您的服务器安全，密码仅会显示一次，请牢记您的密码。"
     log ""
     log "================================================================"
 }


### PR DESCRIPTION
1panel密码默认为明文存储，安全性较低，修改后的密码安全性较高。我将其改为启动服务后移除1pctl文件中密码变量的数值，以此来提高安全性。
测试结果：

- 安装1Panel输出内容
```
[1Panel Log]: 启动 1Panel 服务
[1Panel Log]: 1Panel 服务启动成功!
[1Panel Log]:
[1Panel Log]: =================感谢您的耐心等待，安装已经完成==================
[1Panel Log]:
[1Panel Log]: 请用浏览器访问面板:
[1Panel Log]: 外网地址: http://<remote_ip_address>:37356/71852adadb
[1Panel Log]: 内网地址: http://<local_ip_address>:37356/71852adadb
[1Panel Log]: 面板用户: 8172df49e9
[1Panel Log]: 面板密码: bc8022b371
[1Panel Log]:
[1Panel Log]: 项目官网: https://1panel.cn/
[1Panel Log]: 项目文档: https://1panel.cn/docs
[1Panel Log]: 代码仓库: https://github.com/1Panel-dev/1Panel
[1Panel Log]:
[1Panel Log]: 如果使用的是云服务器，请至安全组开放 37356 端口
[1Panel Log]:
[1Panel Log]: 为了您的服务器安全，在您离开此界面后您将无法查看您的密码，请牢记您的密码。
[1Panel Log]:
[1Panel Log]: ================================================================
```


- 1pctl文件的部分内容
```
#!/bin/bash
action=$1
target=$2
args=$@

BASE_DIR=/opt
ORIGINAL_PORT=37356
ORIGINAL_VERSION=v1.10.5-lts
ORIGINAL_ENTRANCE=71852adadb
ORIGINAL_USERNAME=8172df49e9
ORIGINAL_PASSWORD=**********
```

经过测试，修改后可以使用用户设置的用户名和密码顺利的登录1Panel。